### PR TITLE
Fix file exists issue.

### DIFF
--- a/zip_unicode/main.py
+++ b/zip_unicode/main.py
@@ -159,7 +159,10 @@ class ZipHandler:
 
             logger.info(f"Extracting: {decoded_name}")
             fo = destination / decoded_name
-            fo.parent.mkdir(parents=True, exist_ok=True)
+            parent = fo.parent
+            if parent.exists() and parent.is_file():
+                parent.unlink()
+            parent.mkdir(parents=True, exist_ok=True)
             extract_ok = self._extract_individual(original_name, fo, password)
             if not extract_ok:
                 break

--- a/zip_unicode/main.py
+++ b/zip_unicode/main.py
@@ -159,8 +159,12 @@ class ZipHandler:
 
             logger.info(f"Extracting: {decoded_name}")
             fo = destination / decoded_name
+            if fo.exists() and fo.is_dir():
+                # skip already exists directory
+                continue
             parent = fo.parent
             if parent.exists() and parent.is_file():
+                # parent should be a directory
                 parent.unlink()
             parent.mkdir(parents=True, exist_ok=True)
             extract_ok = self._extract_individual(original_name, fo, password)


### PR DESCRIPTION
I found an issue when trying to extract a ZIP file.
This issue can be reproduced by [this ZIP file](https://denkiyoho.hepco.co.jp/area/data/zip/202301-03_hokkaido_jukyu.zip).

This ZIP file has some directory entries without delimiter, like

```console
$ zipu 202301-03_hokkaido_jukyu.zip 
...
----------------------------- try encoding: ascii -----------------------------
202301/20230101_hokkaido_BGplan.csv
202301/20230101_hokkaido_yosoku.csv
...
202303
202303/20230301_hokkaido_BGplan.csv
202303/20230301_hokkaido_yosoku.csv
...
202301
...
-------------------------------------------------------------------------------
...
```

The entry `202303` makes an empty file and the next entry `202303/20230301_hokkaido_BGplan.csv` will fail because the directory `202303` already exists as a file.

Also, the entry `202301` will fail because `202301` already exists as a directory but the code tries to extract this entry as a file.

I fixed this issue.